### PR TITLE
Adding services parameters in methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 .gopath
 *.test
 vendor
+.idea

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ LIBKERMIT_ENVS := \
 BIND_DIR := "dist"
 LIBKERMIT_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/libkermit/compose/$(BIND_DIR)"
 
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-LIBKERMIT_DEV_IMAGE := libkermit-compose-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
+GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
+LIBKERMIT_DEV_IMAGE := libkermit-compose-dev$(if $(GIT_BRANCH),:$(subst /,-,$(GIT_BRANCH)))
 REPONAME := $(shell echo $(REPO) | tr '[:upper:]' '[:lower:]')
 
 DAEMON_VERSION := $(if $(DAEMON_VERSION),$(DAEMON_VERSION),"default")

--- a/compose.go
+++ b/compose.go
@@ -85,6 +85,7 @@ func (p *Project) Start(services ...string) error {
 	return p.UnPause(services...)
 }
 
+// Unpause only starts created services which are stopped.
 func (p *Project) UnPause(services ...string) error {
 	ctx := context.Background()
 	err := p.composeProject.Start(ctx, services...)
@@ -97,6 +98,7 @@ func (p *Project) UnPause(services ...string) error {
 	return nil
 }
 
+// Pause only stop services without delete them.
 func (p *Project) Pause(services ...string) error {
 	ctx := context.Background()
 	err := p.composeProject.Stop(ctx, 10, services...)

--- a/compose.go
+++ b/compose.go
@@ -82,11 +82,11 @@ func (p *Project) Start(services ...string) error {
 		return err
 	}
 
-	return p.UnPause(services...)
+	return p.StartOnly(services...)
 }
 
-// UnPause only starts created services which are stopped.
-func (p *Project) UnPause(services ...string) error {
+// StartOnly only starts created services which are stopped.
+func (p *Project) StartOnly(services ...string) error {
 	ctx := context.Background()
 	err := p.composeProject.Start(ctx, services...)
 	if err != nil {
@@ -98,8 +98,8 @@ func (p *Project) UnPause(services ...string) error {
 	return nil
 }
 
-// Pause only stop services without delete them.
-func (p *Project) Pause(services ...string) error {
+// StopOnly only stop services without delete them.
+func (p *Project) StopOnly(services ...string) error {
 	ctx := context.Background()
 	err := p.composeProject.Stop(ctx, 10, services...)
 	if err != nil {
@@ -113,7 +113,7 @@ func (p *Project) Pause(services ...string) error {
 // Stop shuts down and clean the project
 func (p *Project) Stop(services ...string) error {
 	// FIXME(vdemeester) handle timeout
-	err := p.Pause(services...)
+	err := p.StopOnly(services...)
 	if err != nil {
 		return err
 	}

--- a/compose.go
+++ b/compose.go
@@ -85,7 +85,7 @@ func (p *Project) Start(services ...string) error {
 	return p.UnPause(services...)
 }
 
-// Unpause only starts created services which are stopped.
+// UnPause only starts created services which are stopped.
 func (p *Project) UnPause(services ...string) error {
 	ctx := context.Background()
 	err := p.composeProject.Start(ctx, services...)

--- a/integration/assets/services.yml
+++ b/integration/assets/services.yml
@@ -1,0 +1,6 @@
+hello:
+  image: busybox
+  command: top
+other:
+  image: busybox
+  command: top

--- a/integration/testing/services_test.go
+++ b/integration/testing/services_test.go
@@ -1,0 +1,22 @@
+package composeit
+
+import (
+	"testing"
+
+	compose "github.com/libkermit/compose/testing"
+)
+
+func TestServicesProject(t *testing.T) {
+	project := compose.CreateProject(t, "services", "../assets/services.yml")
+	project.Start(t, "hello")
+
+	container := project.Container(t, "hello")
+	if container.Name != "/services_hello_1" {
+		t.Fatalf("expected name '/services_hello_1', got %s", container.Name)
+	}
+
+	//"No container found for '%s' service
+	project.NoContainer(t, "other")
+
+	project.Stop(t, "hello")
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -27,15 +27,15 @@ func CreateProject(t *testing.T, name string, composeFiles ...string) *Project {
 }
 
 // Start creates and starts the compose project.
-func (p *Project) Start(t *testing.T) {
-	if err := p.project.Start(); err != nil {
+func (p *Project) Start(t *testing.T, services ...string) {
+	if err := p.project.Start(services...); err != nil {
 		t.Fatalf("error while starting compose project: %s", err.Error())
 	}
 }
 
 // Stop shuts down and clean the project
-func (p *Project) Stop(t *testing.T) {
-	if err := p.project.Stop(); err != nil {
+func (p *Project) Stop(t *testing.T, services ...string) {
+	if err := p.project.Stop(services...); err != nil {
 		t.Fatalf("error while stopping compose project: %s", err.Error())
 	}
 }
@@ -64,4 +64,14 @@ func (p *Project) Container(t *testing.T, service string) types.ContainerJSON {
 		t.Fatalf("error while getting the container for service '%s'", service)
 	}
 	return container
+}
+
+// NoContainer check is there is no container for the service given
+// It fails if there one or more containers or if the error returned
+// does not indicate an empty container list
+func (p *Project) NoContainer(t *testing.T, service string) {
+	validErr := "No container found for '" + service + "' service"
+	if _, err := p.project.Container(service); err == nil || err.Error() != validErr {
+		t.Fatalf("error while getting the container for service '%s'", service)
+	}
 }


### PR DESCRIPTION
This feature allows users to add services as parameters when project is started/stopped.
The pause/unpause methods are added in the way to separate : 
* Service create and service start actions
* Service stop and service delete actions