### PR TITLE
Fix channels opening when services are added/restarted.

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -23,6 +23,7 @@ import (
 
 // Project holds compose related project attributes
 type Project struct {
+	composeFiles   []string
 	composeProject project.APIProject
 	name           string
 	listenChan     chan events.Event
@@ -30,6 +31,7 @@ type Project struct {
 	stopped        chan struct{}
 	deleted        chan struct{}
 	client         client.APIClient
+	hasOpenedChan  bool
 }
 
 // CreateProject creates a compose project with the given name based on the
@@ -58,6 +60,7 @@ func CreateProject(name string, composeFiles ...string) (*Project, error) {
 		return nil, err
 	}
 	p := &Project{
+		composeFiles:   composeFiles,
 		composeProject: composeProject,
 		name:           name,
 		listenChan:     make(chan events.Event),
@@ -65,6 +68,7 @@ func CreateProject(name string, composeFiles ...string) (*Project, error) {
 		stopped:        make(chan struct{}),
 		deleted:        make(chan struct{}),
 		client:         apiClient,
+		hasOpenedChan:  true,
 	}
 
 	// Listen to compose events
@@ -76,6 +80,11 @@ func CreateProject(name string, composeFiles ...string) (*Project, error) {
 
 // Start creates and starts the compose project.
 func (p *Project) Start(services ...string) error {
+	// If project chan are closed, recreate new compose project
+	if !p.hasOpenedChan {
+		newProject, _ := CreateProject(p.name, p.composeFiles...)
+		*p = *newProject
+	}
 	ctx := context.Background()
 	err := p.composeProject.Create(ctx, options.Create{})
 	if err != nil {
@@ -94,7 +103,6 @@ func (p *Project) StartOnly(services ...string) error {
 	}
 	// Wait for compose to start
 	<-p.started
-	close(p.started)
 	return nil
 }
 
@@ -106,7 +114,6 @@ func (p *Project) StopOnly(services ...string) error {
 		return err
 	}
 	<-p.stopped
-	close(p.stopped)
 	return nil
 }
 
@@ -117,14 +124,37 @@ func (p *Project) Stop(services ...string) error {
 	if err != nil {
 		return err
 	}
-	ctx := context.Background()
-	err = p.composeProject.Delete(ctx, options.Delete{}, services...)
+
+	err = p.composeProject.Delete(context.Background(), options.Delete{}, services...)
 	if err != nil {
 		return err
 	}
 	<-p.deleted
-	close(p.deleted)
+
+	existingContainers, err := p.existContainers(project.AnyState)
+	if err != nil {
+		return err
+	}
+	// Close channels only if there are no running services
+	if !existingContainers {
+		p.hasOpenedChan = false
+		close(p.started)
+		close(p.stopped)
+		close(p.deleted)
+		close(p.listenChan)
+	}
 	return nil
+}
+
+// Check if containers exist in the desirated state for the given services
+func (p *Project) existContainers(stateFiltered project.State, services ...string) (bool, error) {
+	existingContainers := false
+	var err error = nil
+	containersFound, err := p.composeProject.Containers(context.Background(), project.Filter{stateFiltered})
+	if err == nil && containersFound != nil && len(containersFound) > 0 {
+		existingContainers = true
+	}
+	return existingContainers, err
 }
 
 // Scale scale a service up

--- a/compose.go
+++ b/compose.go
@@ -149,7 +149,7 @@ func (p *Project) Stop(services ...string) error {
 // Check if containers exist in the desirated state for the given services
 func (p *Project) existContainers(stateFiltered project.State, services ...string) (bool, error) {
 	existingContainers := false
-	var err error = nil
+	var err error
 	containersFound, err := p.composeProject.Containers(context.Background(), project.Filter{stateFiltered})
 	if err == nil && containersFound != nil && len(containersFound) > 0 {
 		existingContainers = true

--- a/integration/check/services_test.go
+++ b/integration/check/services_test.go
@@ -26,4 +26,10 @@ func (s *CheckServicesSuite) TestServicesProject(c *check.C) {
 
 	project.Stop(c, "hello")
 
+	project.Start(c)
+
+	container = project.Container(c, "other")
+	c.Assert(container.Name, check.Equals, "/services_other_1")
+
+	project.Stop(c)
 }

--- a/integration/testing/services_test.go
+++ b/integration/testing/services_test.go
@@ -18,5 +18,15 @@ func TestServicesProject(t *testing.T) {
 	//"No container found for '%s' service
 	project.NoContainer(t, "other")
 
-	project.Stop(t, "hello")
+	project.Start(t, "other")
+
+	container = project.Container(t, "other")
+	if container.Name != "/services_other_1" {
+		t.Fatalf("expected name '/services_other_1', got %s", container.Name)
+	}
+
+	project.Stop(t, "hello", "other")
+
+	project.Start(t)
+	project.Stop(t)
 }


### PR DESCRIPTION
Services management (#6 and #7 ) feature show that closing channels after all actions don't allow starting multiple services or restarting project.

This PR allows to close channels only if all project services are deleted and allows to recreate environment if necessary.