### PR TITLE
Add services parameter to the create action

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -86,7 +86,7 @@ func (p *Project) Start(services ...string) error {
 		*p = *newProject
 	}
 	ctx := context.Background()
-	err := p.composeProject.Create(ctx, options.Create{})
+	err := p.composeProject.Create(ctx, options.Create{}, services...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR follow the #6 in the way to use the given services even during the project creation.